### PR TITLE
Makefile: automatically download submodules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,11 @@ PDF_DIR_MARKER = pdf/.dir_exists
 AUX_DIR_MARKER = aux/.dir_exists
 O_DIR_MARKER = o/.dir_exists
 
-default: thesis compile
+default: submodules thesis compile
 all: default
+
+submodules:
+	git submodules update --init --recursive
 
 compile: $(ALL_LHS_FILES:tex/%.lhs=aux/%.o)
 


### PR DESCRIPTION
Was just trying to set this up. I ran `make`, but it simply failed, unable to find the target for `pdf/thesis.pdf`. I ran `git submodule update --init --recursive`, which helped a bit, but then kept bumping into things. Figured I would document what I found thus far.
